### PR TITLE
Test Case: Verify worm direction change

### DIFF
--- a/tests/test_script.js
+++ b/tests/test_script.js
@@ -1,0 +1,10 @@
+// tests/test_script.js
+
+const { changeDirection, worm } = require('../script.js');
+
+test('changeDirection should change the direction', () => {
+  const initialDirection = 'up';
+  worm.direction = initialDirection;
+  changeDirection();
+  expect(worm.direction).not.toBe(initialDirection);
+});


### PR DESCRIPTION
This pull request introduces a test case to verify that the `changeDirection` function correctly changes the direction of the worm. The test is designed to fail initially, confirming the presence of a bug.