### PR TITLE
Test: Verify worm boundary conditions

### DIFF
--- a/tests/test_worm_position.js
+++ b/tests/test_worm_position.js
@@ -1,0 +1,12 @@
+// tests/test_worm_position.js
+const { updateWormPosition, worm, gridSize, gameBoardSize } = require('../script.js');
+const chai = require('chai');
+const assert = chai.assert;
+
+describe('Worm Boundary Conditions', () => {
+    it('should stay within bounds (left)', () => {
+        const initialWorm = { x: 0, y: 0 };
+        updateWormPosition(initialWorm, -1, 0, gameBoardSize, gridSize);
+        assert.strictEqual(worm.x, 0, 'X should stay at 0 (left boundary)');
+    });
+});


### PR DESCRIPTION
This pull request adds a test case to verify that the `updateWormPosition` function correctly prevents the worm from moving outside the defined game boundaries.