### PR TITLE
Fix: Local test loading

### DIFF
--- a/crawling-worm-website/tests/index.test.js
+++ b/crawling-worm-website/tests/index.test.js
@@ -1,0 +1,24 @@
+// crawling-worm-website/tests/index.test.js
+import { test, expect } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+
+const getFileContent = async (filePath) => {
+  try {
+    const absolutePath = path.resolve(__dirname, '..', filePath);
+    const content = await fs.readFile(absolutePath, 'utf-8');
+    return content;
+  } catch (error) {
+    console.error(`Error reading file ${filePath}:`, error);
+    throw error;
+  }
+};
+
+test('website loads without errors', async () => {
+  try {
+    const html = await getFileContent('index.html');
+    expect(html).toContain('<html');
+  } catch (error) {
+    expect(error).toBeFalsy(); // Ensure the test fails if there's an error
+  }
+});


### PR DESCRIPTION
The tests were updated to read the `index.html` file from the local file system instead of trying to fetch it from `localhost`.