### PR TITLE
Fix: Verify GSAP library inclusion in index.html

### DIFF
--- a/crawling-worm-website/tests/gsap-inclusion.test.js
+++ b/crawling-worm-website/tests/gsap-inclusion.test.js
@@ -1,0 +1,9 @@
+// crawling-worm-website/tests/gsap-inclusion.test.js
+import { readFile } from 'node:fs/promises';
+import { expect, it } from 'vitest';
+
+
+it('should include GSAP library via CDN in index.html', async () => {
+  const htmlContent = await readFile('crawling-worm-website/index.html', 'utf-8');
+  expect(htmlContent).toContain('https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js');
+});


### PR DESCRIPTION
This pull request includes a test to verify the inclusion of the GSAP library in the `index.html` file.  The test uses vitest and checks for the presence of the GSAP CDN link.

The test should fail if the library is not included, which would highlight a problem in the setup.