### PR TITLE
Implement basic plan parsing logic

### DIFF
--- a/src/plan_reader.py
+++ b/src/plan_reader.py
@@ -1,0 +1,25 @@
+# src/plan_reader.py
+
+import re
+
+
+def parse_plan(text):
+    """Parses a plan text and extracts tasks.
+
+    Args:
+        text: The plan text.
+
+    Returns:
+        A list of task descriptions.
+    """
+    tasks = []
+    for line in text.splitlines():
+        if line.startswith("Task:"):
+            tasks.append(line[5:].strip())
+        elif line.startswith("Step:"):
+            tasks.append(line[5:].strip())
+        elif re.match(r"^\d+\.\s", line):
+            match = re.match(r"^\d+\.\s(.*?)$", line)
+            if match:
+                tasks.append(match.group(1).strip())
+    return tasks

--- a/test/test_plan_reader.py
+++ b/test/test_plan_reader.py
@@ -1,0 +1,42 @@
+# test/test_plan_reader.py
+import unittest
+from src.plan_reader import parse_plan
+
+
+class TestPlanReader(unittest.TestCase):
+
+    def test_empty_plan(self):
+        plan_text = ""
+        tasks = parse_plan(plan_text)
+        self.assertEqual(tasks, [])
+
+    def test_single_task(self):
+        plan_text = "Task: Implement feature X"
+        tasks = parse_plan(plan_text)
+        self.assertEqual(tasks, ["Implement feature X"])
+
+    def test_multiple_tasks(self):
+        plan_text = """
+Task: Implement feature X
+Task: Write tests
+"""
+        tasks = parse_plan(plan_text)
+        self.assertEqual(tasks, ["Implement feature X", "Write tests"])
+
+    def test_step_task(self):
+        plan_text = "Step: Refactor code"
+        tasks = parse_plan(plan_text)
+        self.assertEqual(tasks, ["Refactor code"])
+
+    def test_numbered_list_task(self):
+        plan_text = "1. Deploy to production"
+        tasks = parse_plan(plan_text)
+        self.assertEqual(tasks, ["Deploy to production"])
+
+    def test_handles_extra_whitespace(self):
+        plan_text = "Task:   Clean up   "
+        tasks = parse_plan(plan_text)
+        self.assertEqual(tasks, ["Clean up"])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request implements a basic plan parsing mechanism to identify tasks from plain text plan files, recognizing lines starting with 'Task:', 'Step:', or numbered lists. It extracts the task description and includes corresponding unit tests.