### PR TITLE
Implement env commands

### DIFF
--- a/cli-project/cli/commands/env_commands.py
+++ b/cli-project/cli/commands/env_commands.py
@@ -1,0 +1,35 @@
+# cli-project/cli/commands/env_commands.py
+import os
+import json
+import click
+
+
+@click.group()
+def env():
+    """Manages environment variables."""
+    pass
+
+
+@env.command()
+@click.argument('key')
+def get(key):
+    """Gets the value of an environment variable."""
+    value = os.environ.get(key)
+    if value is not None:
+        click.echo(value)
+        exit(0)
+    else:
+        click.echo(f"Environment variable '{key}' not found.")
+        exit(1)
+
+
+@env.command()
+@click.option('--format', type=click.Choice(['text', 'json']), default='text', help='Output format.')
+def list(format):
+    """Lists all environment variables."""
+    if format == 'text':
+        for key, value in os.environ.items():
+            click.echo(f'{key}={value}')
+    elif format == 'json':
+        click.echo(json.dumps(dict(os.environ), indent=4))
+    exit(0)

--- a/cli-project/tests/test_env_commands.py
+++ b/cli-project/tests/test_env_commands.py
@@ -1,0 +1,45 @@
+# cli-project/tests/test_env_commands.py
+import os
+import json
+import pytest
+from click.testing import CliRunner
+from cli.cli import cli
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_env_get_success(runner, monkeypatch):
+    monkeypatch.setenv("TEST_VAR", "test_value")
+    result = runner.invoke(cli, ["env", "get", "TEST_VAR"])
+    assert result.exit_code == 0
+    assert "test_value" in result.output
+
+
+def test_env_get_not_found(runner):
+    result = runner.invoke(cli, ["env", "get", "NON_EXISTENT_VAR"])
+    assert result.exit_code == 1
+    assert "Environment variable 'NON_EXISTENT_VAR' not found." in result.output
+
+
+def test_env_list_text(runner, monkeypatch):
+    monkeypatch.setenv("TEST_VAR1", "test_value1")
+    monkeypatch.setenv("TEST_VAR2", "test_value2")
+    result = runner.invoke(cli, ["env", "list"])
+    assert result.exit_code == 0
+    assert "TEST_VAR1=test_value1" in result.output
+    assert "TEST_VAR2=test_value2" in result.output
+
+
+def test_env_list_json(runner, monkeypatch):
+    monkeypatch.setenv("TEST_VAR1", "test_value1")
+    monkeypatch.setenv("TEST_VAR2", "test_value2")
+    result = runner.invoke(cli, ["env", "list", "--format", "json"])
+    assert result.exit_code == 0
+    output = json.loads(result.output)
+    assert "TEST_VAR1" in output
+    assert output["TEST_VAR1"] == "test_value1"
+    assert "TEST_VAR2" in output
+    assert output["TEST_VAR2"] == "test_value2"


### PR DESCRIPTION
This pull request implements the `env` subcommands (`get`, `list`) as defined in `command_structure.txt`. These commands allow AI agents to access environment variables within the Docker container.

- Implemented `env get` subcommand.
- Implemented `env list` subcommand.
- Used `click` to define subcommands and options.
- Accessed environment variables using `os.environ`.
- Implemented output formatting in JSON and text.
- Implemented error handling.

Tests have been added to verify the functionality.