### PR TITLE
Fix: SP-487 ModuleNotFoundError

### DIFF
--- a/cli-project/cli/cli.py
+++ b/cli-project/cli/cli.py
@@ -1,16 +1,14 @@
 # cli-project/cli/cli.py
 import click
-from cli.commands.exec_command import exec_command
+from .commands import env_commands, exec_command, file_commands
 
-@click.group(name="cli")
+@click.group()
 def cli():
-    """A simple CLI tool."""
     pass
 
-cli.add_command(exec_command)
-
-from cli.commands.file_commands import file
-cli.add_command(file)
+cli.add_command(env_commands.env)
+cli.add_command(file_commands.file)
+cli.add_command(exec_command.exec_command)
 
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
Fixes the ModuleNotFoundError by updating the import paths in cli/cli.py.